### PR TITLE
Chore/change text

### DIFF
--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -15,7 +15,7 @@ const teamOptionsJa = team.reduce((acc, team) => {
 
 export const translations = {
   ja: {
-    title: '訪問者登録',
+    title: '訪問者登',
     description: 'お越しいただきありがとうございます',
     name: {
       label: '氏名 *',

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -15,57 +15,57 @@ const teamOptionsJa = team.reduce((acc, team) => {
 
 export const translations = {
   ja: {
-    title: '訪問者登',
-    description: 'お越しいただきありがとうございます',
+    title: 'ゲスト登録',
+    description: 'ご来社ありがとうございます',
     name: {
-      label: '氏名 *',
-      placeholder: 'お名前',
-      error: '名前は2文字以上で入力してください。',
+      label: 'お名前 *',
+      placeholder: 'お名前をご入力ください',
+      error: 'お名前は2文字以上でご入力ください',
     },
     company: {
-      label: '会社 / 所属',
-      placeholder: '会社名',
+      label: '会社名・所属',
+      placeholder: '会社名をご入力ください',
     },
     team: {
-      label: '訪問先 *',
-      placeholder: '訪問先を選択',
-      error: '訪問先を選択してください。',
+      label: '面会希望のメンバー *',
+      placeholder: 'メンバーをお選びください',
+      error: '面会希望のメンバーを選択してください',
     },
     purpose: {
-      label: '目的 *',
-      placeholder: '目的を選択',
-      error: '目的を選択してください。',
+      label: '訪問目的 *',
+      placeholder: '目的をお選びください',
+      error: '訪問目的を選択してください',
     },
     teamOptions: teamOptionsJa,
     purposeOptions: {
-      Meeting: '会議',
+      Meeting: '打ち合わせ',
       Interview: '面接',
       Delivery: '配達',
       Other: 'その他',
     },
     button: {
-      submit: 'チームに通知',
-      submitting: '通知中...',
+      submit: '受付を完了する',
+      submitting: '送信中...',
     },
     success: {
-      title: 'ありがとうございます！',
-      message: 'チームに通知しました。しばらくお待ちください。',
-      button: '新しい登録',
+      title: '受付完了',
+      message: '担当者に連絡いたしましたので、少々お待ちください',
+      button: '戻る',
     },
     error: {
       title: 'エラー',
-      message: '通知の送信に失敗しました。もう一度お試しください。',
+      message: '送信に失敗しました。お手数ですが、もう一度お試しください',
     },
     langSwitcher: {
-      label: 'Language',
+      label: '言語',
       options: {
         en: 'English',
         ja: '日本語',
       }
     },
     homePage: {
-      welcome: 'アレスグッドへようこそ！',
-      subtitle: 'ご到着をお知らせください'
+      welcome: 'アレスグッドへようこそ',
+      subtitle: 'ゲスト情報をご入力ください'
     }
   },
   en: {
@@ -104,7 +104,7 @@ export const translations = {
     success: {
       title: 'Thank You!',
       message: 'Your team has been notified and someone will be with you shortly.',
-      button: 'Submit Another',
+      button: 'back to start',
     },
     error: {
       title: 'Error',


### PR DESCRIPTION
This pull request involves updates to the Japanese translations in the `lib/i18n.ts` file to improve clarity and consistency. The changes primarily affect the labels, placeholders, and messages for various fields in the visitor registration form.

### Updates to Japanese translations:

* Changed the title and description to more accurately reflect the purpose of the form.
* Updated labels, placeholders, and error messages for the `name`, `company`, `team`, and `purpose` fields to provide clearer instructions.
* Modified button texts and success messages to ensure they are more user-friendly and informative.
* Adjusted the `langSwitcher` label from "Language" to "言語" to match the context of the form.
* Improved the home page welcome message and subtitle for better user guidance.

### Minor updates to English translations:

* Updated the success button text from "Submit Another" to "back to start" for consistency.